### PR TITLE
Replace log with logrus

### DIFF
--- a/scaleway/data_source_image.go
+++ b/scaleway/data_source_image.go
@@ -2,7 +2,7 @@ package scaleway
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"time"

--- a/scaleway/data_source_security_group.go
+++ b/scaleway/data_source_security_group.go
@@ -2,7 +2,7 @@ package scaleway
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	api "github.com/nicolai86/scaleway-sdk"

--- a/scaleway/data_source_volume.go
+++ b/scaleway/data_source_volume.go
@@ -2,7 +2,7 @@ package scaleway
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	api "github.com/nicolai86/scaleway-sdk"

--- a/scaleway/logger.go
+++ b/scaleway/logger.go
@@ -1,7 +1,7 @@
 package scaleway
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	sdkLogger "github.com/scaleway/scaleway-sdk-go/logger"

--- a/scaleway/resource_ip.go
+++ b/scaleway/resource_ip.go
@@ -1,7 +1,7 @@
 package scaleway
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	api "github.com/nicolai86/scaleway-sdk"

--- a/scaleway/resource_security_group.go
+++ b/scaleway/resource_security_group.go
@@ -2,7 +2,7 @@ package scaleway
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/scaleway/resource_security_group_rule.go
+++ b/scaleway/resource_security_group_rule.go
@@ -2,7 +2,7 @@ package scaleway
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	api "github.com/nicolai86/scaleway-sdk"

--- a/scaleway/resource_server.go
+++ b/scaleway/resource_server.go
@@ -2,7 +2,7 @@ package scaleway
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/scaleway/resource_volume.go
+++ b/scaleway/resource_volume.go
@@ -2,7 +2,7 @@ package scaleway
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	api "github.com/nicolai86/scaleway-sdk"

--- a/scaleway/resource_volume_attachment.go
+++ b/scaleway/resource_volume_attachment.go
@@ -2,7 +2,7 @@ package scaleway
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/vendor/github.com/aws/aws-sdk-go/aws/logger.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/logger.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/golang/protobuf/proto/clone.go
+++ b/vendor/github.com/golang/protobuf/proto/clone.go
@@ -36,7 +36,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/equal.go
+++ b/vendor/github.com/golang/protobuf/proto/equal.go
@@ -35,7 +35,7 @@ package proto
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/lib.go
+++ b/vendor/github.com/golang/protobuf/proto/lib.go
@@ -224,7 +224,7 @@ To create and play with a Test object:
 	package main
 
 	import (
-		"log"
+		log "github.com/sourcegraph-ce/logrus"
 
 		"github.com/golang/protobuf/proto"
 		pb "./example.pb"
@@ -266,7 +266,7 @@ package proto
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/golang/protobuf/proto/properties.go
+++ b/vendor/github.com/golang/protobuf/proto/properties.go
@@ -37,7 +37,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/golang/protobuf/proto/text.go
+++ b/vendor/github.com/golang/protobuf/proto/text.go
@@ -40,7 +40,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/go-hclog/intlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/intlogger.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"runtime"
 	"sort"

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -3,7 +3,7 @@ package hclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // NewNullLogger instantiates a Logger for which all calls

--- a/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/server.go
+++ b/vendor/github.com/hashicorp/go-plugin/server.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"os"
 	"os/signal"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
+++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"math/rand"
 	"net/http"

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sourcegraph-ce/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/logging.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/transport.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"reflect"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_config.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_import_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_import_state.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/field_reader_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/field_reader_config.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_timeout.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_timeout.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/command/format/plan.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/command/format/plan.go
@@ -3,7 +3,7 @@ package format
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/marshal.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/marshal.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/walk.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/walk.go
@@ -2,7 +2,7 @@ package dag
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"time"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/httpclient/client.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/httpclient/client.go
@@ -2,7 +2,7 @@ package httpclient
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/from_module.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/from_module.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/getter.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/getter.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/module_install.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/module_install.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/eval.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/eval.go
@@ -2,7 +2,7 @@ package lang
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/hcl2/ext/dynblock"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs/encoding.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs/encoding.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"unicode/utf8"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/functions.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/functions.go
@@ -74,7 +74,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"keys":             funcs.KeysFunc,
 			"length":           funcs.LengthFunc,
 			"list":             funcs.ListFunc,
-			"log":              funcs.LogFunc,
+			log "github.com/sourcegraph-ce/logrus":              funcs.LogFunc,
 			"lookup":           funcs.LookupFunc,
 			"lower":            stdlib.LowerFunc,
 			"map":              funcs.MapFunc,

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/modsdir/manifest.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/modsdir/manifest.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/find.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/find.go
@@ -2,7 +2,7 @@ package discovery
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/get.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/get.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/registry/client.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/registry/client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"path"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version1_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version1_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/mitchellh/copystructure"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version2_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version2_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/sync.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/sync.go
@@ -1,7 +1,7 @@
 package states
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/disco.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/disco.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"mime"
 	"net/http"
 	"net/url"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/host.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/host.go
@@ -3,7 +3,7 @@ package disco
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provisioner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	plugin "github.com/hashicorp/go-plugin"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context_input.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context_input.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/hcl2/hcl"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/diff.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_apply.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_apply.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_context_builtin.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_context_builtin.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count_boundary.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count_boundary.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcl2/hcl"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_import_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_import_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_lang.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_lang.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_output.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_read_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_read_data.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state_upgrade.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_validate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_variable.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_variable.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/evaluate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/evaluate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder_refresh.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_walk_context.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_walk_context.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_abstract.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_abstract.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_apply.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_apply.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_destroy.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_destroy.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_plan.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_plan.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/schemas.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/schemas.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state_upgrade_v2_to_v3.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state_upgrade_v2_to_v3.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_config_resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_config_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_schema.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_config.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_cbd.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_cbd.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_edge.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_edge.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_expand.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_expand.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_count.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_count.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provisioner.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_reference.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_reference.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_removed_modules.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_removed_modules.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_targets.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_targets.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/yamux/mux.go
+++ b/vendor/github.com/hashicorp/yamux/mux.go
@@ -3,7 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 )

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/mitchellh/cli/help.go
+++ b/vendor/github.com/mitchellh/cli/help.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 )

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -4,7 +4,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
@@ -9,7 +9,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/posener/complete/log.go
+++ b/vendor/github.com/posener/complete/log.go
@@ -2,7 +2,7 @@ package complete
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/scaleway/scaleway-sdk-go/logger/default_logger.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/logger/default_logger.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 )

--- a/vendor/github.com/spf13/afero/memmap.go
+++ b/vendor/github.com/spf13/afero/memmap.go
@@ -15,7 +15,7 @@ package afero
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/golang.org/x/crypto/ssh/channel.go
+++ b/vendor/golang.org/x/crypto/ssh/channel.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 )
 

--- a/vendor/golang.org/x/crypto/ssh/handshake.go
+++ b/vendor/golang.org/x/crypto/ssh/handshake.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 )

--- a/vendor/golang.org/x/crypto/ssh/mux.go
+++ b/vendor/golang.org/x/crypto/ssh/mux.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/golang.org/x/crypto/ssh/transport.go
+++ b/vendor/golang.org/x/crypto/ssh/transport.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // debugTransport if set, will print packet types as they go over the

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -33,7 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	mathrand "math/rand"
 	"net"

--- a/vendor/golang.org/x/net/http2/write.go
+++ b/vendor/golang.org/x/net/http2/write.go
@@ -7,7 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 

--- a/vendor/golang.org/x/net/internal/timeseries/timeseries.go
+++ b/vendor/golang.org/x/net/internal/timeseries/timeseries.go
@@ -7,7 +7,7 @@ package timeseries // import "golang.org/x/net/internal/timeseries"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"runtime"
 	"sort"

--- a/vendor/golang.org/x/net/trace/histogram.go
+++ b/vendor/golang.org/x/net/trace/histogram.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"sync"
 

--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -68,7 +68,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
+++ b/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
@@ -10,7 +10,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"golang.org/x/oauth2"

--- a/vendor/golang.org/x/text/unicode/bidi/core.go
+++ b/vendor/golang.org/x/text/unicode/bidi/core.go
@@ -4,7 +4,7 @@
 
 package bidi
 
-import "log"
+import log "github.com/sourcegraph-ce/logrus"
 
 // This implementation is a port based on the reference implementation found at:
 // https://www.unicode.org/Public/PROGRAMS/BidiReferenceJava/

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/google.golang.org/appengine/internal/identity_vm.go
+++ b/vendor/google.golang.org/appengine/internal/identity_vm.go
@@ -7,7 +7,7 @@
 package internal
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/main_vm.go
+++ b/vendor/google.golang.org/appengine/internal/main_vm.go
@@ -8,7 +8,7 @@ package internal
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/google.golang.org/appengine/internal/net.go
+++ b/vendor/google.golang.org/appengine/internal/net.go
@@ -8,7 +8,7 @@ package internal
 // It is only used for API calls.
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"runtime"
 	"sync"

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -21,7 +21,7 @@ package grpclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 )


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-scaleway', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
scaleway
scripts
.github
vendor
website
.git
ISSUE_TEMPLATE
contributing
go.opencensus.io
cloud.google.com
gopkg.in
google.golang.org
golang.org
github.com
plugin
stats
internal
resource
tag
trace
metric
ochttp
propagation
b3
view
internal
tagencoding
tracestate
internal
propagation
metricproducer
metricdata
go
storage
internal
iam
compute
optional
trace
version
metadata
yaml.v2
grpc
genproto
appengine
api
keepalive
grpclog
naming
health
stats
binarylog
codes
internal
connectivity
test
status
credentials
serviceconfig
resolver
tap
peer
balancer
encoding
metadata
grpc_health_v1
grpc_binarylog_v1
grpcrand
syscall
transport
envconfig
binarylog
backoff
grpcsync
channelz
balancerload
bufconn
internal
dns
passthrough
base
roundrobin
proto
googleapis
rpc
iam
type
api
code
status
v1
expr
annotations
datastore
urlfetch
internal
internal
cloudkey
cloudpb
app_identity
datastore
urlfetch
base
log
remote_api
modules
storage
transport
googleapi
option
internal
gensupport
iterator
v1
http
internal
propagation
transport
internal
uritemplates
x
crypto
net
sys
sync
xerrors
oauth2
text
cast5
poly1305
ssh
internal
openpgp
curve25519
blowfish
bcrypt
ed25519
subtle
chacha20
s2k
armor
packet
elgamal
errors
internal
edwards25519
http
idna
internal
context
http2
trace
httpguts
timeseries
ctxhttp
hpack
unix
cpu
errgroup
internal
jwt
internal
google
jws
unicode
secure
transform
bidi
norm
bidirule
ulikunitz
stretchr
nicolai86
fatih
googleapis
scaleway
zclconf
apparentlymart
golang
oklog
jmespath
google
hashicorp
posener
spf13
mitchellh
davecgh
pmezard
aws
vmihailenco
mattn
armon
bgentry
agext
xz
lzma
internal
hash
xlog
testify
require
assert
scaleway-sdk
color
gax-go
v2
scaleway-sdk-go
logger
internal
scw
namegenerator
api
validation
async
auth
parameter
errors
marshaler
account
instance
baremetal
marketplace
registry
rdb
lb
k8s
v2alpha1
v1
v1
v1
v1
v1
v1
v1
go-cty-yaml
go-cty
cty
set
json
msgpack
function
convert
gocty
stdlib
go-textseg
go-cidr
textseg
cidr
protobuf
proto
ptypes
protoc-gen-go
any
duration
timestamp
descriptor
run
go-jmespath
uuid
go-cmp
cmp
internal
diff
flags
value
function
go-plugin
go-getter
yamux
errwrap
go-uuid
terraform-plugin-sdk
go-version
hcl2
golang-lru
go-multierror
go-cleanhttp
hil
terraform-config-inspect
go-retryablehttp
hcl
go-safetemp
logutils
go-hclog
internal
plugin
helper
url
plugin
internal
terraform
helper
command
httpclient
tfdiags
providers
configs
provisioners
dag
earlyconfig
moduledeps
plugin
initwd
flatmap
addrs
states
helper
lang
registry
tfplugin5
plans
modsdir
svchost
version
format
hcl2shim
configload
configschema
discovery
convert
statefile
plugin
config
didyoumean
funcs
blocktoattr
response
regsrc
objchange
disco
auth
structure
schema
hashcode
resource
logging
acctest
validation
hcldec
ext
gohcl
hcled
hclwrite
hcl
hclparse
typeexpr
dynblock
json
hclsyntax
simplelru
ast
tfconfig
json
hcl
token
scanner
parser
token
scanner
ast
strconv
parser
complete
cmd
match
install
afero
mem
go-homedir
cli
reflectwalk
go-testing-interface
copystructure
mapstructure
go-wordwrap
colorstring
go-spew
spew
go-difflib
difflib
aws-sdk-go
service
internal
private
aws
sts
s3
stsiface
sdkio
ini
sdkrand
shareddefaults
s3err
sdkuri
protocol
json
eventstream
rest
restxml
query
xml
jsonutil
eventstreamapi
queryutil
xmlutil
ec2metadata
signer
csm
defaults
session
endpoints
request
awserr
corehandlers
awsutil
credentials
client
v4
endpointcreds
ec2rolecreds
processcreds
stscreds
metadata
msgpack
codes
go-colorable
go-isatty
go-radix
go-netrc
speakeasy
netrc
levenshtein
docs
r
guides
d
objects
info
branches
logs
refs
hooks
97
1b
31
08
94
8d
65
20
99
9f
24
4e
eb
6e
18
b6
e2
78
e6
66
b0
49
fe
01
bd
57
89
5a
c5
1e
e4
f5
d0
1c
44
95
72
dc
12
b7
ee
11
c8
22
1f
53
7a
47
5c
7c
07
fa
59
87
81
9e
75
52
8e
d6
96
ba
e3
29
02
f2
ac
3f
71
4a
ec
10
0e
e7
69
42
a9
9c
a3
6c
db
ea
ff
bf
dd
76
43
3e
34
60
1d
c9
4c
05
ca
26
06
a4
21
d2
85
19
fd
82
9b
a0
c2
f3
fb
b8
b4
cb
0b
c1
a6
0f
74
93
61
5b
51
cf
d1
c7
de
2a
f6
e9
pack
f7
ef
9a
8b
e8
da
d7
b3
ce
79
3a
b5
f1
ae
e0
be
28
a2
info
f8
80
e5
ed
a7
3c
9d
1a
15
a5
56
7d
c6
2b
fc
ad
09
2e
d4
4b
50
98
73
6d
27
f0
3b
70
7e
bc
7f
46
88
0c
c0
af
d5
a8
5e
35
16
b1
40
67
aa
ab
8c
3d
41
e1
b9
6b
23
84
00
37
83
4f
d3
54
0d
33
2f
8f
d9
39
36
55
63
17
77
c4
92
68
f9
c3
04
38
2c
8a
64
b2
7b
48
32
cd
91
6a
14
5d
bb
2d
cc
5f
58
45
f4
03
a1
25
6f
86
62
df
4d
0a
13
30
90
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)